### PR TITLE
Wrong register usage in `mla` instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "unarm"
-version = "1.6.0"
+version = "1.6.1"
 
 [[package]]
 name = "unarm-fuzz"

--- a/disasm/Cargo.toml
+++ b/disasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unarm"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"

--- a/disasm/tests/test_arm_v4t.rs
+++ b/disasm/tests/test_arm_v4t.rs
@@ -241,8 +241,8 @@ mod tests {
 
     #[test]
     fn test_mla() {
-        assert_asm!(0xe0212394, "mla r2, r4, r3, r1");
-        assert_asm!(0xa0312394, "mlasge r2, r4, r3, r1");
+        assert_asm!(0xe0212394, "mla r1, r4, r3, r2");
+        assert_asm!(0xa0312394, "mlasge r1, r4, r3, r2");
     }
 
     #[test]

--- a/disasm/tests/test_arm_v5te.rs
+++ b/disasm/tests/test_arm_v5te.rs
@@ -301,8 +301,8 @@ mod tests {
 
     #[test]
     fn test_mla() {
-        assert_asm!(0xe0212394, "mla r2, r4, r3, r1");
-        assert_asm!(0xa0312394, "mlasge r2, r4, r3, r1");
+        assert_asm!(0xe0212394, "mla r1, r4, r3, r2");
+        assert_asm!(0xa0312394, "mlasge r1, r4, r3, r2");
     }
 
     #[test]
@@ -454,10 +454,10 @@ mod tests {
 
     #[test]
     fn test_smla() {
-        assert_asm!(0xe1012384, "smlabb r2, r4, r3, r1");
-        assert_asm!(0xe10123a4, "smlatb r2, r4, r3, r1");
-        assert_asm!(0xe10123c4, "smlabt r2, r4, r3, r1");
-        assert_asm!(0xe10123e4, "smlatt r2, r4, r3, r1");
+        assert_asm!(0xe1012384, "smlabb r1, r4, r3, r2");
+        assert_asm!(0xe10123a4, "smlatb r1, r4, r3, r2");
+        assert_asm!(0xe10123c4, "smlabt r1, r4, r3, r2");
+        assert_asm!(0xe10123e4, "smlatt r1, r4, r3, r2");
     }
 
     #[test]
@@ -472,8 +472,8 @@ mod tests {
 
     #[test]
     fn test_smlaw() {
-        assert_asm!(0xe1212384, "smlawb r2, r4, r3, r1");
-        assert_asm!(0xe12123c4, "smlawt r2, r4, r3, r1");
+        assert_asm!(0xe1212384, "smlawb r1, r4, r3, r2");
+        assert_asm!(0xe12123c4, "smlawt r1, r4, r3, r2");
     }
 
     #[test]

--- a/disasm/tests/test_arm_v6k.rs
+++ b/disasm/tests/test_arm_v6k.rs
@@ -342,8 +342,8 @@ mod tests {
 
     #[test]
     fn test_mla() {
-        assert_asm!(0xe0212394, "mla r2, r4, r3, r1");
-        assert_asm!(0xa0312394, "mlasge r2, r4, r3, r1");
+        assert_asm!(0xe0212394, "mla r1, r4, r3, r2");
+        assert_asm!(0xa0312394, "mlasge r1, r4, r3, r2");
     }
 
     #[test]
@@ -636,10 +636,16 @@ mod tests {
 
     #[test]
     fn test_smla() {
-        assert_asm!(0xe1012384, "smlabb r2, r4, r3, r1");
-        assert_asm!(0xe10123a4, "smlatb r2, r4, r3, r1");
-        assert_asm!(0xe10123c4, "smlabt r2, r4, r3, r1");
-        assert_asm!(0xe10123e4, "smlatt r2, r4, r3, r1");
+        assert_asm!(0xe1012384, "smlabb r1, r4, r3, r2");
+        assert_asm!(0xe10123a4, "smlatb r1, r4, r3, r2");
+        assert_asm!(0xe10123c4, "smlabt r1, r4, r3, r2");
+        assert_asm!(0xe10123e4, "smlatt r1, r4, r3, r2");
+    }
+
+    #[test]
+    fn test_smlad() {
+        assert_asm!(0xe7012314, "smlad r1, r4, r3, r2");
+        assert_asm!(0x07012334, "smladxeq r1, r4, r3, r2");
     }
 
     #[test]
@@ -660,8 +666,8 @@ mod tests {
 
     #[test]
     fn test_smlaw() {
-        assert_asm!(0xe1212384, "smlawb r2, r4, r3, r1");
-        assert_asm!(0xe12123c4, "smlawt r2, r4, r3, r1");
+        assert_asm!(0xe1212384, "smlawb r1, r4, r3, r2");
+        assert_asm!(0xe12123c4, "smlawt r1, r4, r3, r2");
     }
 
     #[test]

--- a/specs/arm.yaml
+++ b/specs/arm.yaml
@@ -1251,9 +1251,9 @@ opcodes:
     bitmask: 0x0fe000f0
     pattern: 0x00200090
     modifiers: [S, cond]
-    args: [Rd, Rm, Rs, Rn]
-    defs: [Rd]
-    uses: [Rm, Rs, Rn]
+    args: [RdHi, Rm, Rs, Rn_12]
+    defs: [RdHi]
+    uses: [Rm, Rs, Rn_12]
 
   - name: mov
     desc: Move
@@ -1786,9 +1786,9 @@ opcodes:
     pattern: 0x01000080
     flags: [!MinVersion V5Te]
     modifiers: [x, y, cond]
-    args: [Rd, Rm, Rs, Rn]
-    defs: [Rd]
-    uses: [Rm, Rs, Rn]
+    args: [RdHi, Rm, Rs, Rn_12]
+    defs: [RdHi]
+    uses: [Rm, Rs, Rn_12]
 
   - name: smlad
     desc: Signed Multiply Accumulate Dual
@@ -1796,9 +1796,9 @@ opcodes:
     pattern: 0x07000010
     flags: [!MinVersion V6K]
     modifiers: [dual, cond]
-    args: [Rd, Rm, Rs, Rn]
-    defs: [Rd]
-    uses: [Rm, Rs, Rn]
+    args: [RdHi, Rm, Rs, Rn_12]
+    defs: [RdHi]
+    uses: [Rm, Rs, Rn_12]
 
   - name: smlal
     desc: Signed Multiply Accumulate Long
@@ -1835,9 +1835,9 @@ opcodes:
     pattern: 0x01200080
     flags: [!MinVersion V5Te]
     modifiers: [y, cond]
-    args: [Rd, Rm, Rs, Rn]
-    defs: [Rd]
-    uses: [Rm, Rs, Rn]
+    args: [RdHi, Rm, Rs, Rn_12]
+    defs: [RdHi]
+    uses: [Rm, Rs, Rn_12]
 
   - name: smlsd
     desc: Signed Multiply Subtract accumulate Dual


### PR DESCRIPTION
The following instructions has the wrong register order: 
- `mla`
- `smla`
- `smlad`
- `smlaw`

I missed that `Rd` and `Rn` swaps places in these instructions, so that has now been fixed.

Now there's also a unit test for `smlad`.