### PR TITLE
Add privileged LDM with writeback

### DIFF
--- a/disasm/tests/test_arm_v4t.rs
+++ b/disasm/tests/test_arm_v4t.rs
@@ -145,6 +145,10 @@ mod tests {
         assert_asm!(0xe8550003, "ldmda r5, {r0, r1}^");
         assert_asm!(0xe8568003, "ldmda r6, {r0, r1, pc}^");
         assert_asm!(0xe8778003, "ldmda r7!, {r0, r1, pc}^");
+        assert_asm!(
+            0xe9f17fff,
+            "ldmib r1!, {r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, sp, lr}^"
+        );
     }
 
     #[test]

--- a/disasm/tests/test_arm_v5te.rs
+++ b/disasm/tests/test_arm_v5te.rs
@@ -184,6 +184,10 @@ mod tests {
         assert_asm!(0xe8550003, "ldmda r5, {r0, r1}^");
         assert_asm!(0xe8568003, "ldmda r6, {r0, r1, pc}^");
         assert_asm!(0xe8778003, "ldmda r7!, {r0, r1, pc}^");
+        assert_asm!(
+            0xe9f17fff,
+            "ldmib r1!, {r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, sp, lr}^"
+        );
     }
 
     #[test]

--- a/disasm/tests/test_arm_v6k.rs
+++ b/disasm/tests/test_arm_v6k.rs
@@ -214,6 +214,10 @@ mod tests {
         assert_asm!(0xe8550003, "ldmda r5, {r0, r1}^");
         assert_asm!(0xe8568003, "ldmda r6, {r0, r1, pc}^");
         assert_asm!(0xe8778003, "ldmda r7!, {r0, r1, pc}^");
+        assert_asm!(
+            0xe9f17fff,
+            "ldmib r1!, {r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, sp, lr}^"
+        );
     }
 
     #[test]

--- a/specs/arm.yaml
+++ b/specs/arm.yaml
@@ -1063,6 +1063,17 @@ opcodes:
     defs: [registers_c]
     uses: [Rn]
 
+  # Non-standard, but some platforms have this
+  - name: ldm$pw
+    desc: Load Multiple (privilege, writeback)
+    bitmask: 0x0e708000
+    pattern: 0x08700000
+    modifiers: [addr_ldm_stm, cond]
+    tags: [loads_multiple]
+    args: [Rn_wb, registers_c]
+    defs: [registers_c]
+    uses: [Rn_wb]
+
   - name: ldm$pc$w
     desc: Load Multiple (including PC, writeback)
     bitmask: 0x0e708000


### PR DESCRIPTION
I ran into this unsupported instruction in the ITCM for Castlevania: Portrait of Ruin (ACBE00):
```asm
01ffe274 ff 7f f1 e9     ldmib      r1!,{r0,r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,sp,lr}^
```
It seems to be the load counterpart of this instruction: 4c2c3b957f53be344ea198efb29b9ba0b26a4c49

ds-decomp 0.2.2 currently errors on delink for PoR due to bad analysis, but with this instruction supported it works perfectly and matches when linked.
