### PR TITLE
Add "Undefined" instruction for V5Te

### DIFF
--- a/disasm/tests/test_arm_v4t.rs
+++ b/disasm/tests/test_arm_v4t.rs
@@ -477,6 +477,13 @@ mod tests {
     }
 
     #[test]
+    fn test_udf() {
+        assert_asm!(0xe7f000f0, "udf #0x0");
+        assert_asm!(0xe7fa45f5, "udf #0xa455");
+        assert_asm!(0xe7ffffff, "udf #0xffff");
+    }
+
+    #[test]
     fn test_umlal() {
         assert_asm!(0xe0a12394, "umlal r2, r1, r4, r3");
         assert_asm!(0xa0b12394, "umlalsge r2, r1, r4, r3");

--- a/disasm/tests/test_arm_v5te.rs
+++ b/disasm/tests/test_arm_v5te.rs
@@ -642,6 +642,13 @@ mod tests {
     }
 
     #[test]
+    fn test_udf() {
+        assert_asm!(0xe7f000f0, "udf #0x0");
+        assert_asm!(0xe7fa45f5, "udf #0xa455");
+        assert_asm!(0xe7ffffff, "udf #0xffff");
+    }
+
+    #[test]
     fn test_umlal() {
         assert_asm!(0xe0a12394, "umlal r2, r1, r4, r3");
         assert_asm!(0xa0b12394, "umlalsge r2, r1, r4, r3");

--- a/disasm/tests/test_arm_v6k.rs
+++ b/disasm/tests/test_arm_v6k.rs
@@ -973,6 +973,7 @@ mod tests {
     fn test_udf() {
         assert_asm!(0xe7f000f0, "udf #0x0");
         assert_asm!(0xe7fa45f5, "udf #0xa455");
+        assert_asm!(0xe7ffffff, "udf #0xffff");
     }
 
     #[test]

--- a/disasm/tests/test_thumb_v4t.rs
+++ b/disasm/tests/test_thumb_v4t.rs
@@ -237,4 +237,9 @@ mod tests {
     fn test_tst() {
         assert_asm!(0x4217, "tst r7, r2");
     }
+
+    #[test]
+    fn test_udf() {
+        assert_asm!(0xde42, "udf #0x42");
+    }
 }

--- a/disasm/tests/test_thumb_v5te.rs
+++ b/disasm/tests/test_thumb_v5te.rs
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn test_bkpt() {
-        assert_asm!(0xde42, "bkpt #0x42");
+        assert_asm!(0xbe42, "bkpt #0x42");
     }
 
     #[test]
@@ -250,5 +250,10 @@ mod tests {
     #[test]
     fn test_tst() {
         assert_asm!(0x4217, "tst r7, r2");
+    }
+
+    #[test]
+    fn test_udf() {
+        assert_asm!(0xde42, "udf #0x42");
     }
 }

--- a/disasm/tests/test_thumb_v6k.rs
+++ b/disasm/tests/test_thumb_v6k.rs
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn test_bkpt() {
-        assert_asm!(0xde42, "bkpt #0x42");
+        assert_asm!(0xbe42, "bkpt #0x42");
     }
 
     #[test]
@@ -286,6 +286,11 @@ mod tests {
     #[test]
     fn test_tst() {
         assert_asm!(0x4217, "tst r7, r2");
+    }
+
+    #[test]
+    fn test_udf() {
+        assert_asm!(0xde42, "udf #0x42");
     }
 
     #[test]

--- a/specs/arm.yaml
+++ b/specs/arm.yaml
@@ -2408,7 +2408,6 @@ opcodes:
     desc: Permanently Undefined
     bitmask: 0xfff000f0
     pattern: 0xe7f000f0
-    flags: [!MinVersion V5Te]
     modifiers: [cond]
     args: [immed_16]
 

--- a/specs/arm.yaml
+++ b/specs/arm.yaml
@@ -2408,7 +2408,7 @@ opcodes:
     desc: Permanently Undefined
     bitmask: 0xfff000f0
     pattern: 0xe7f000f0
-    flags: [!MinVersion V6K]
+    flags: [!MinVersion V5Te]
     modifiers: [cond]
     args: [immed_16]
 

--- a/specs/thumb.yaml
+++ b/specs/thumb.yaml
@@ -546,7 +546,7 @@ opcodes:
   - name: bkpt
     desc: Breakpoint
     bitmask: 0xff00
-    pattern: 0xde00
+    pattern: 0xbe00
     flags: [!MinVersion V5Te]
     args: [immed_8]
 
@@ -1077,6 +1077,12 @@ opcodes:
     tags: [updates_condition_flags]
     args: [Rn_0, Rm_3]
     uses: [Rn_0, Rm_3]
+
+  - name: udf
+    desc: Permanently Undefined
+    bitmask: 0xff00
+    pattern: 0xde00
+    args: [immed_8]
 
   - name: uxtb
     desc: Zero Extend Byte to 32 bits


### PR DESCRIPTION
This instruction seems to be (in)valid for V5 as well as V6, as it appears in Castlevania: Dawn of Sorrow (ACVE00):
```asm
0206e950 ff ff ff e7   udf        #0xffff
0206e954 1e ff 2f e1   bx         lr
```
This function is called when an assertion fails to intentionally crash.

Also, this instruction is supported by Ghidra for ARM V5 (but not V4, as far as I can see).