### PR TITLE
Implement From<u8> for Opcode

### DIFF
--- a/disasm/src/thumb/generated.rs
+++ b/disasm/src/thumb/generated.rs
@@ -1441,6 +1441,23 @@ impl Opcode {
         83
     }
 }
+impl From<u8> for Opcode {
+    #[inline]
+    fn from(value: u8) -> Self {
+        if value > 82 {
+            Self::Illegal
+        } else {
+            // Safety: The enum is repr(u8) and the value is within the enum's range
+            unsafe { core::mem::transmute::<u8, Self>(value) }
+        }
+    }
+}
+impl From<Opcode> for u8 {
+    #[inline]
+    fn from(value: Opcode) -> Self {
+        value as u8
+    }
+}
 impl Ins {
     /// Rd_0: Destination register
     #[inline(always)]


### PR DESCRIPTION
Allows converting arm::Opcode and thumb::Opcode to/from `u8`. This is for an objdiff feature PR I'm working on to preview data values based on the opcode that loads it.

Based on https://github.com/encounter/ppc750cl/commit/c8026715f05eb7a86178a31d1b63c5cb3d998804